### PR TITLE
Failed json error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-electrumx-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Light electrum x websocket client",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws-electrumx-client",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Light electrum x websocket client",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/electrum-ws.ts
+++ b/src/lib/electrum-ws.ts
@@ -170,7 +170,9 @@ export class ElectrumWS extends Observable {
     return new Promise<ResponseType>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.requests.delete(id);
-        reject(new Error('Request timeout'));
+        reject(
+          new Error(`ElectrumWS request timeout. request ID: ${id} (${method})`)
+        );
       }, REQUEST_TIMEOUT);
 
       this.requests.set(id, {
@@ -305,6 +307,12 @@ export class ElectrumWS extends Observable {
       const response = this.parseLine(line);
       if (!response) continue;
       this.fire(ElectrumWSEvent.MESSAGE, response);
+
+      if (typeof response !== 'object') {
+        if (this.verbose)
+          console.debug('received a non-JSON response:', response);
+        continue;
+      }
 
       if ('id' in response && this.requests.has(response.id)) {
         const request = this.requests.get(response.id);

--- a/src/lib/electrum-ws.ts
+++ b/src/lib/electrum-ws.ts
@@ -360,7 +360,7 @@ export class ElectrumWS extends Observable {
 
     if (this.verbose)
       console.debug(
-        'Failed to parse JSON, retrying together with next message'
+        `Failed to parse JSON, retrying together with next message: "${line}"`
       );
     this.incompleteMessage = line;
     return false;

--- a/src/lib/electrum-ws.ts
+++ b/src/lib/electrum-ws.ts
@@ -356,8 +356,10 @@ export class ElectrumWS extends Observable {
   private parseLine(line: string): RpcResponse | RpcRequest | false {
     try {
       const parsed = JSON.parse(line);
-      this.incompleteMessage = '';
-      return parsed;
+      if (typeof parsed === 'object') {
+        this.incompleteMessage = '';
+        return parsed;
+      }
     } catch (error) {
       // Ignore
     }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Update errors message and fix parseLine error in case of JSON.parse does not fail but is not an object.

- **What is the current behavior?** (You can also link to an open issue here)

It causes some request timeouts.

- **What is the new behavior (if this is a feature change)?**

throw an error as soon as we receive it.
