### PR TITLE
custom parsing for JSON RPC errors

### DIFF
--- a/src/lib/electrum-ws.spec.ts
+++ b/src/lib/electrum-ws.spec.ts
@@ -60,7 +60,7 @@ test('should be able to send multiple requests using batchRequest', async (t) =>
   t.pass();
 });
 
-test('should throw an error if the method name is invalid', async (t) => {
+test('should throw an error if the method name is unsupported', async (t) => {
   const electrum = new ElectrumWS(localURL);
   await t.throwsAsync(async () => {
     await electrum.request<number>(
@@ -73,8 +73,9 @@ test('should throw an error if the method name is invalid', async (t) => {
 
 test('should throw and error if the request parameters are invalid', async (t) => {
   const electrum = new ElectrumWS(localURL);
-  await t.throwsAsync(async () => {
+  const error = await t.throwsAsync(async () => {
     await electrum.request<number>('blockchain.estimatefee', [1]); // should be a number, not an array
   });
+  t.is(error.message, 'non-integerblocks_count');
   t.pass();
 });

--- a/src/lib/rpc-error.spec.ts
+++ b/src/lib/rpc-error.spec.ts
@@ -1,0 +1,32 @@
+import test from 'ava';
+
+import { RPCError } from './rpc-error';
+
+const tests = [
+  {
+    input:
+      'sendrawtransactionRPCerror:{"code":-27,"message":"Transactionalreadyinblockchain"}',
+    output: 'Transaction already in chain (code: -27)',
+  },
+  {
+    input: 'sendrawtransactionRPCerror:{"code":-26,"message":""}',
+    output: 'Transaction or block was rejected by network rules (code: -26)',
+  },
+];
+
+const invalidTests = ['code:1', 'invalid parameters', 'code:1, message:2'];
+
+for (const valid of tests) {
+  test(`should parse ${valid.input} correctly`, (t) => {
+    const error = new RPCError(valid.input);
+    t.is(error.message, valid.output);
+  });
+}
+
+for (const invalid of invalidTests) {
+  test(`should throw an error for ${invalid}`, (t) => {
+    t.throws(() => {
+      new RPCError(invalid);
+    });
+  });
+}

--- a/src/lib/rpc-error.ts
+++ b/src/lib/rpc-error.ts
@@ -1,0 +1,40 @@
+// https://github.com/bitcoin/bitcoin/blob/v25.0/src/rpc/protocol.h#L38-L50 b
+const JSON_RPC_ERRORS: Map<number, string> = new Map([
+  [-32700, 'Parse error'],
+  [-32600, 'Invalid request'],
+  [-32601, 'Method not found'],
+  [-32602, 'Invalid params'],
+  [-32603, 'Internal error'],
+  [-1, 'Miscellaneous error'],
+  [-3, 'Unexpected type was passed as parameter'],
+  [-5, 'Invalid address or key'],
+  [-7, 'Ran out of memory during operation'],
+  [-8, 'Invalid, missing or duplicate parameter'],
+  [-20, 'Database error'],
+  [-22, 'Error parsing JSON'],
+  [-25, 'An error occured while transaction or block submission'],
+  [-26, 'Transaction or block was rejected by network rules'],
+  [-27, 'Transaction already in chain'],
+  [-28, 'Client still warming up'],
+  [-32, 'RPC method is deprecated'],
+]);
+
+export class RPCError extends Error {
+  code: number;
+
+  constructor(public str: string) {
+    const code = findRPCErrorCode(str);
+    if (!code) throw new Error('Could not find RPC error code in string');
+    const message = JSON_RPC_ERRORS.get(code) || 'Unknown JSON RPC error';
+    super(`${message} (code: ${code})`);
+  }
+}
+
+function findRPCErrorCode(str: string): number | false {
+  const match = str.match(/"code":\s*(-?\d+)/);
+  if (!match) {
+    return false;
+  }
+
+  return parseInt(match[1], 10);
+}


### PR DESCRIPTION
- **What is the current behavior?** (You can also link to an open issue here)

JSON RPC errors are thrown as raw strings `sendrawtransactionRPCerror:{"code":-27,"message":"Transactionalreadyinblockchain"}`

- **What is the new behavior (if this is a feature change)?**

`ElectrumWS` parses and sends fancy RPC error mapped with code.

- **Other information**:

it closes #2 
